### PR TITLE
chore: bump version of SSK to 0.2.3

### DIFF
--- a/prod/registry.json
+++ b/prod/registry.json
@@ -10,7 +10,7 @@
     "developer": "MetaMask",
     "website": "https://metamask.github.io/snap-simple-keyring/latest/",
     "auditUrls": ["https://example.org"],
-    "version": "0.1.2",
-    "lastUpdated": "April 20, 2023"
+    "version": "0.2.3",
+    "lastUpdated": "Sep 19, 2023"
   }
 }


### PR DESCRIPTION
Bumps the version of SSK to 0.2.3