### PR TITLE
fix: removes dummy audit URLs, and bumps version

### DIFF
--- a/dev/registry.json
+++ b/dev/registry.json
@@ -9,7 +9,7 @@
     "tags": ["EOA"],
     "developer": "MetaMask",
     "website": "https://www.consensys.net/",
-    "auditUrls": ["auditUrl1", "auditUrl2"],
+    "auditUrls": [],
     "version": "0.2.4",
     "lastUpdated": "Oct 5, 2023"
   },
@@ -23,7 +23,7 @@
     "tags": ["4337", "Smart Contract"],
     "developer": "MetaMask",
     "website": "https://www.consensys.net/",
-    "auditUrls": ["auditUrl1", "auditUrl2"],
+    "auditUrls": [],
     "version": "1.0.0",
     "lastUpdated": "April 20, 2023"
   },
@@ -37,7 +37,7 @@
     "tags": ["MPC", "Shared Custody"],
     "developer": "MetaMask",
     "website": "https://tss.ac/",
-    "auditUrls": ["auditUrl1", "auditUrl2"],
+    "auditUrls": [],
     "version": "1.0.0",
     "lastUpdated": "April 20, 2023"
   },

--- a/dev/registry.json
+++ b/dev/registry.json
@@ -12,47 +12,5 @@
     "auditUrls": [],
     "version": "0.2.4",
     "lastUpdated": "Oct 5, 2023"
-  },
-  "1f2fd474-107c-408b-be0d-f4b312156b87": {
-    "id": "1f2fd474-107c-408b-be0d-f4b312156b87",
-    "snapId": "npm:@metamask/snap-account-abstraction",
-    "iconUrl": "",
-    "snapTitle": "MetaMask Account Abstraction Snap",
-    "snapSlug": "Use account abstraction 4337",
-    "snapDescription": "This snap allows the use of account abstraction with EIP4337.",
-    "tags": ["4337", "Smart Contract"],
-    "developer": "MetaMask",
-    "website": "https://www.consensys.net/",
-    "auditUrls": [],
-    "version": "1.0.0",
-    "lastUpdated": "April 20, 2023"
-  },
-  "475633a1-c68d-4d04-a7e1-145719e878d1": {
-    "id": "475633a1-c68d-4d04-a7e1-145719e878d1",
-    "snapId": "npm:@metamask/snap-tss",
-    "iconUrl": "",
-    "snapTitle": "MetaMask TSS",
-    "snapSlug": "Secure your account tss",
-    "snapDescription": "Threshold signature schemes (TSS) allow multiple collaborating participants to sign a message or transaction. The private key is shared between the participants using a technique called multi-party computation (MPC) which ensures that the entire private key is never exposed to any participant; the process for generating key shares is called distributed key generation (DKG). Before a signature can be generated all participants must generate key shares using DKG and store their key shares securely; the number of participants and threshold for signature generation must be decided in advance. Unlike other techniques such as Shamirs Secret Sharing (SSS) the entire private key is never revealed to any single participant and is therefore more secure as it does not have the trusted dealer problem.",
-    "tags": ["MPC", "Shared Custody"],
-    "developer": "MetaMask",
-    "website": "https://tss.ac/",
-    "auditUrls": [],
-    "version": "1.0.0",
-    "lastUpdated": "April 20, 2023"
-  },
-  "c840abe3-a961-4f2e-8b16-fba45b170d98": {
-    "id": "c840abe3-a961-4f2e-8b16-fba45b170d98",
-    "snapId": "local:http://localhost:8080",
-    "iconUrl": "",
-    "snapTitle": "Local Test Simple Keyring",
-    "snapSlug": "Local version of Simple Keyring Snap",
-    "snapDescription": "Keyring Snap that uses the local version of the Simple Keyring Snap",
-    "tags": ["MPC", "Shared Custody"],
-    "developer": "MetaMask",
-    "website": "http://localhost:8000/",
-    "auditUrls": [],
-    "version": "0.0.1",
-    "lastUpdated": "April 20, 2023"
   }
 }

--- a/dev/registry.json
+++ b/dev/registry.json
@@ -10,8 +10,8 @@
     "developer": "MetaMask",
     "website": "https://www.consensys.net/",
     "auditUrls": ["auditUrl1", "auditUrl2"],
-    "version": "0.1.2",
-    "lastUpdated": "April 20, 2023"
+    "version": "0.2.4",
+    "lastUpdated": "Oct 5, 2023"
   },
   "1f2fd474-107c-408b-be0d-f4b312156b87": {
     "id": "1f2fd474-107c-408b-be0d-f4b312156b87",
@@ -51,7 +51,7 @@
     "tags": ["MPC", "Shared Custody"],
     "developer": "MetaMask",
     "website": "http://localhost:8000/",
-    "auditUrls": ["auditUrl1", "auditUrl2"],
+    "auditUrls": [],
     "version": "0.0.1",
     "lastUpdated": "April 20, 2023"
   }

--- a/prod/registry.json
+++ b/prod/registry.json
@@ -9,8 +9,8 @@
     "tags": ["EOA"],
     "developer": "MetaMask",
     "website": "https://metamask.github.io/snap-simple-keyring/latest/",
-    "auditUrls": ["https://example.org"],
-    "version": "0.2.3",
-    "lastUpdated": "Sep 19, 2023"
+    "auditUrls": [],
+    "version": "0.2.4",
+    "lastUpdated": "Oct 5, 2023"
   }
 }

--- a/prod/registry.json
+++ b/prod/registry.json
@@ -1,16 +1,1 @@
-{
-  "a51ea3a8-f1b0-4613-9440-b80e2236713b": {
-    "id": "a51ea3a8-f1b0-4613-9440-b80e2236713b",
-    "snapId": "npm:@metamask/snap-simple-keyring-snap",
-    "iconUrl": "",
-    "snapTitle": "MetaMask Simple Keyring",
-    "snapSlug": "Simple example keyring using private keys.",
-    "snapDescription": "A simple private key is a randomly generated string of characters that is used to sign transactions. This private key is stored securely within this snap.",
-    "tags": ["EOA"],
-    "developer": "MetaMask",
-    "website": "https://metamask.github.io/snap-simple-keyring/latest/",
-    "auditUrls": [],
-    "version": "0.2.4",
-    "lastUpdated": "Oct 5, 2023"
-  }
-}
+{}


### PR DESCRIPTION
Removes the dummy audit urls and bumps the version